### PR TITLE
fix(dep): bump flask

### DIFF
--- a/cdiserrors/__init__.py
+++ b/cdiserrors/__init__.py
@@ -129,4 +129,4 @@ def make_json_error(ex):
 
 def setup_default_handlers(app):
     for code in default_exceptions.iterkeys():
-        app.error_handler_spec[None][code] = make_json_error
+        app.register_error_handler(code, make_json_error)

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'cdislogging',
-        'Flask==0.10.1',
-        'Werkzeug==0.12.2',
+        'Flask>=0.10.1,<=1.0.0',
+        'Werkzeug>=0.12.2,<=1.0.0',
     ],
     dependency_links=[
         'git+https://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging',


### PR DESCRIPTION
don't require version pin because it's a library
fix the error handling registration, don't use the lower level way, it doesn't work anymore